### PR TITLE
Better handling when not in init

### DIFF
--- a/Server Tools/underwater.alias
+++ b/Server Tools/underwater.alias
@@ -14,7 +14,7 @@ image     = args.last('image', image)
 footer    = "!underwater alias made by Landsil"
 
 c = combat()
-combatants = [c.get_combatant(t) for t in args.get('t') if c.get_combatant(t)] if args.get('t') else c.combatants
+combatants = ([c.get_combatant(t) for t in args.get('t') if c.get_combatant(t)] if args.get('t') else c.combatants) if c else []
 
 # Check arg for fire and if true check if combat is live, apply fire resistance to everyone if yes.
 fire  = "&1&" if "&1&".lower() in ['fire'] else False


### PR DESCRIPTION
While adding the target stuff I made the behaviour worse when not in iinit. Fixed it here with an empty array of combatants when not in combat

Sorry for not spotting that problem before. But it is a bit nicer now if not in init. 